### PR TITLE
Wrap variables to handle special characters

### DIFF
--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -224,7 +224,7 @@ catch_workers_output = <%= @catch_workers_output %>
 env[<%= var %>] = $<%= var %>
 <% end -%>
 <% @env_value.sort_by {|key,value| key}.each do |key,value| -%>
-env[<%= key %>] = <%= value %>
+env[<%= key %>] = '<%= value %>'
 <% end -%>
 
 ; Additional php.ini defines, specific to this pool of workers. These settings


### PR DESCRIPTION
Some environment variables use special characters, such as urls, security tokens and 
passwords. This causes the fpm to hang if we dos not wrap with single quotes.
